### PR TITLE
Don't make symbols from character vector

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # usemodels (development version)
 
+* Fixed bug in handling of variables for `step_string2factor()`
+
 # usemodels 0.0.1
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/misc.R
+++ b/R/misc.R
@@ -107,7 +107,6 @@ factor_check <- function(base, rec, add, colors = TRUE) {
     purrr::map_lgl(rec$template %>% dplyr::select(dplyr::one_of(nominal)),
                    rlang::is_character)
   if (any(is_str)) {
-    nominal <- rlang::syms(nominal[is_str])
     selector <- rlang::expr(one_of(!!!nominal))
     step_expr <- rlang::expr(step_string2factor(!!selector))
     base <-

--- a/R/misc.R
+++ b/R/misc.R
@@ -107,7 +107,7 @@ factor_check <- function(base, rec, add, colors = TRUE) {
     purrr::map_lgl(rec$template %>% dplyr::select(dplyr::one_of(nominal)),
                    rlang::is_character)
   if (any(is_str)) {
-    selector <- rlang::expr(one_of(!!!nominal))
+    selector <- rlang::expr(one_of(!!!nominal[is_str]))
     step_expr <- rlang::expr(step_string2factor(!!selector))
     base <-
       base %>%


### PR DESCRIPTION
This PR closes #7 by unquoting/splicing the character vector into `one_of()`.

``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(ggplot2)
library(recipes)
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step

usemodels::use_glmnet(cty ~ ., data = mpg)
#> glmnet_recipe <- 
#>   recipe(formula = cty ~ ., data = mpg) %>% 
#>   step_string2factor(one_of("manufacturer", "model", "trans", "drv", "fl", "class")) %>% 
#>   step_novel(all_nominal(), -all_outcomes()) %>% 
#>   step_dummy(all_nominal(), -all_outcomes()) %>% 
#>   step_zv(all_predictors()) %>% 
#>   step_normalize(all_predictors(), -all_nominal()) 
#> 
#> glmnet_spec <- 
#>   linear_reg(penalty = tune(), mixture = tune()) %>% 
#>   set_mode("regression") %>% 
#>   set_engine("glmnet") 
#> 
#> glmnet_workflow <- 
#>   workflow() %>% 
#>   add_recipe(glmnet_recipe) %>% 
#>   add_model(glmnet_spec) 
#> 
#> glmnet_grid <- tidyr::crossing(penalty = 10^seq(-6, -1, length.out = 20), mixture = c(0.05, 
#>     0.2, 0.4, 0.6, 0.8, 1)) 
#> 
#> glmnet_tune <- 
#>   tune_grid(glmnet_workflow, resamples = stop("add your rsample object"), grid = glmnet_grid)

glmnet_recipe <- 
  recipe(formula = cty ~ ., data = mpg) %>% 
  step_string2factor(one_of("manufacturer", "model", "trans", "drv", "fl", "class")) %>% 
  step_novel(all_nominal(), -all_outcomes()) %>% 
  step_dummy(all_nominal(), -all_outcomes()) %>% 
  step_zv(all_predictors()) %>% 
  step_normalize(all_predictors(), -all_nominal()) 

prep(glmnet_recipe, mpg) %>% juice()
#> # A tibble: 234 x 77
#>     displ   year     cyl   hwy   cty manufacturer_ch… manufacturer_do…
#>     <dbl>  <dbl>   <dbl> <dbl> <int>            <dbl>            <dbl>
#>  1 -1.29  -0.998 -1.17   0.934    18           -0.297           -0.432
#>  2 -1.29  -0.998 -1.17   0.934    21           -0.297           -0.432
#>  3 -1.14   0.998 -1.17   1.27     20           -0.297           -0.432
#>  4 -1.14   0.998 -1.17   1.10     21           -0.297           -0.432
#>  5 -0.520 -0.998  0.0689 0.430    16           -0.297           -0.432
#>  6 -0.520 -0.998  0.0689 0.430    18           -0.297           -0.432
#>  7 -0.288  0.998  0.0689 0.598    18           -0.297           -0.432
#>  8 -1.29  -0.998 -1.17   0.430    18           -0.297           -0.432
#>  9 -1.29  -0.998 -1.17   0.262    16           -0.297           -0.432
#> 10 -1.14   0.998 -1.17   0.766    20           -0.297           -0.432
#> # … with 224 more rows, and 70 more variables: manufacturer_ford <dbl>,
#> #   manufacturer_honda <dbl>, manufacturer_hyundai <dbl>,
#> #   manufacturer_jeep <dbl>, manufacturer_land.rover <dbl>,
#> #   manufacturer_lincoln <dbl>, manufacturer_mercury <dbl>,
#> #   manufacturer_nissan <dbl>, manufacturer_pontiac <dbl>,
#> #   manufacturer_subaru <dbl>, manufacturer_toyota <dbl>,
#> #   manufacturer_volkswagen <dbl>, model_a4 <dbl>, model_a4.quattro <dbl>,
#> #   model_a6.quattro <dbl>, model_altima <dbl>, model_c1500.suburban.2wd <dbl>,
#> #   model_camry <dbl>, model_camry.solara <dbl>, model_caravan.2wd <dbl>,
#> #   model_civic <dbl>, model_corolla <dbl>, model_corvette <dbl>,
#> #   model_dakota.pickup.4wd <dbl>, model_durango.4wd <dbl>,
#> #   model_expedition.2wd <dbl>, model_explorer.4wd <dbl>,
#> #   model_f150.pickup.4wd <dbl>, model_forester.awd <dbl>,
#> #   model_grand.cherokee.4wd <dbl>, model_grand.prix <dbl>, model_gti <dbl>,
#> #   model_impreza.awd <dbl>, model_jetta <dbl>, model_k1500.tahoe.4wd <dbl>,
#> #   model_land.cruiser.wagon.4wd <dbl>, model_malibu <dbl>, model_maxima <dbl>,
#> #   model_mountaineer.4wd <dbl>, model_mustang <dbl>,
#> #   model_navigator.2wd <dbl>, model_new.beetle <dbl>, model_passat <dbl>,
#> #   model_pathfinder.4wd <dbl>, model_ram.1500.pickup.4wd <dbl>,
#> #   model_range.rover <dbl>, model_sonata <dbl>, model_tiburon <dbl>,
#> #   model_toyota.tacoma.4wd <dbl>, trans_auto.l3. <dbl>, trans_auto.l4. <dbl>,
#> #   trans_auto.l5. <dbl>, trans_auto.l6. <dbl>, trans_auto.s4. <dbl>,
#> #   trans_auto.s5. <dbl>, trans_auto.s6. <dbl>, trans_manual.m5. <dbl>,
#> #   trans_manual.m6. <dbl>, drv_f <dbl>, drv_r <dbl>, fl_d <dbl>, fl_e <dbl>,
#> #   fl_p <dbl>, fl_r <dbl>, class_compact <dbl>, class_midsize <dbl>,
#> #   class_minivan <dbl>, class_pickup <dbl>, class_subcompact <dbl>,
#> #   class_suv <dbl>
```

<sup>Created on 2020-10-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>