### PR TITLE
Use more specific datasets for examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,35 +2,36 @@ Package: usemodels
 Title: Boilerplate Code for 'Tidymodels' Analyses
 Version: 0.1.0.9000
 Authors@R: 
-    c(
-    person(
-        given = "Max",
-        family = "Kuhn",
-        email = "max@rstudio.com",
-        comment = c(ORCID = "0000-0003-2402-136X"),
-        role = c("aut", "cre")
-        ),
-    person("RStudio", role = "cph"))
-Description: Code snippets to fit models using the tidymodels framework can be easily created for a given data set. 
-URL: https://usemodels.tidymodels.org/, https://github.com/tidymodels/usemodels
-BugReports: https://github.com/tidymodels/usemodels/issues
+    c(person(given = "Max",
+             family = "Kuhn",
+             role = c("aut", "cre"),
+             email = "max@rstudio.com",
+             comment = c(ORCID = "0000-0003-2402-136X")),
+      person(given = "RStudio",
+             role = "cph"))
+Description: Code snippets to fit models using the tidymodels framework
+    can be easily created for a given data set.
 License: MIT + file LICENSE
-Suggests: 
-    testthat,
-    spelling,
-    covr,
-    palmerpenguins
-Encoding: UTF-8
-LazyData: true
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1.9000
-Language: en-US
+URL: https://usemodels.tidymodels.org/,
+    https://github.com/tidymodels/usemodels
+BugReports: https://github.com/tidymodels/usemodels/issues
 Imports: 
-    tune (>= 0.1.2),
     cli,
+    dplyr,
+    purrr,
     recipes (>= 0.1.15),
     rlang,
-    purrr,
-    dplyr,
-    tidyr
+    tidyr,
+    tune (>= 0.1.2)
+Suggests: 
+    covr,
+    modeldata,
+    palmerpenguins,
+    spelling,
+    testthat
 Config/testthat/edition: 3
+Encoding: UTF-8
+Language: en-US
+LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.1.1.9001

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Imports:
 Suggests: 
     covr,
     modeldata,
-    palmerpenguins,
     spelling,
     testthat
 Config/testthat/edition: 3

--- a/R/use.R
+++ b/R/use.R
@@ -27,10 +27,12 @@
 #' The syntax is opinionated and should not be considered the exact answer for
 #' every data analysis. It has reasonable defaults.
 #' @examples
-#' library(palmerpenguins)
-#' data(penguins)
-#' use_glmnet(species ~ ., data = penguins)
-#' use_glmnet( body_mass_g ~ ., data = penguins, verbose = TRUE, prefix = "gunter")
+#' library(modeldata)
+#' data(ad_data)
+#' use_glmnet(Class ~ ., data = ad_data)
+#'
+#' data(Sacramento)
+#' use_glmnet(price ~ ., data = Sacramento, verbose = TRUE, prefix = "sac_homes")
 #' @export
 #' @rdname templates
 use_glmnet <- function(formula, data, prefix = "glmnet", verbose = FALSE, tune = TRUE, colors = TRUE) {

--- a/man/templates.Rd
+++ b/man/templates.Rd
@@ -101,8 +101,10 @@ The syntax is opinionated and should not be considered the exact answer for
 every data analysis. It has reasonable defaults.
 }
 \examples{
-library(palmerpenguins)
-data(penguins)
-use_glmnet(species ~ ., data = penguins)
-use_glmnet( body_mass_g ~ ., data = penguins, verbose = TRUE, prefix = "gunter")
+library(modeldata)
+data(ad_data)
+use_glmnet(Class ~ ., data = ad_data)
+
+data(Sacramento)
+use_glmnet(price ~ ., data = Sacramento, verbose = TRUE, prefix = "sac_homes")
 }

--- a/tests/testthat/test-templates.R
+++ b/tests/testthat/test-templates.R
@@ -1,4 +1,4 @@
-library(palmerpenguins)
+library(modeldata)
 data("penguins")
 
 penguins$island <- as.character(penguins$island)


### PR DESCRIPTION
Closes #19 

This PR switches out the Palmer penguins dataset in the examples for two more clearly "regression" and "classification" dataset. The penguins are super nice and fun, but handling the missing data is awkward in this kind of example (we did earlier decide that we didn't want to put default missing data handling in usemodels functions since it depends on your specific situation) and there are benefits to having these more focused datasets there instead.

The new examples give results like this:

``` r
library(usemodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
library(modeldata)
data(ad_data)
use_glmnet(Class ~ ., data = ad_data)
#> glmnet_recipe <- 
#>   recipe(formula = Class ~ ., data = ad_data) %>% 
#>   step_novel(all_nominal_predictors()) %>% 
#>   step_dummy(all_nominal_predictors()) %>% 
#>   step_zv(all_predictors()) %>% 
#>   step_normalize(all_numeric_predictors()) 
#> 
#> glmnet_spec <- 
#>   logistic_reg(penalty = tune(), mixture = tune()) %>% 
#>   set_mode("classification") %>% 
#>   set_engine("glmnet") 
#> 
#> glmnet_workflow <- 
#>   workflow() %>% 
#>   add_recipe(glmnet_recipe) %>% 
#>   add_model(glmnet_spec) 
#> 
#> glmnet_grid <- tidyr::crossing(penalty = 10^seq(-6, -1, length.out = 20), mixture = c(0.05, 
#>     0.2, 0.4, 0.6, 0.8, 1)) 
#> 
#> glmnet_tune <- 
#>   tune_grid(glmnet_workflow, resamples = stop("add your rsample object"), grid = glmnet_grid)

data(Sacramento)
use_glmnet(price ~ ., data = Sacramento, verbose = TRUE, prefix = "sac_homes")
#> sac_homes_recipe <- 
#>   recipe(formula = price ~ ., data = Sacramento) %>% 
#>   step_novel(all_nominal_predictors()) %>% 
#>   ## This model requires the predictors to be numeric. The most common 
#>   ## method to convert qualitative predictors to numeric is to create 
#>   ## binary indicator variables (aka dummy variables) from these 
#>   ## predictors. 
#>   step_dummy(all_nominal_predictors()) %>% 
#>   ## Regularization methods sum up functions of the model slope 
#>   ## coefficients. Because of this, the predictor variables should be on 
#>   ## the same scale. Before centering and scaling the numeric predictors, 
#>   ## any predictors with a single unique value are filtered out. 
#>   step_zv(all_predictors()) %>% 
#>   step_normalize(all_numeric_predictors()) 
#> 
#> sac_homes_spec <- 
#>   linear_reg(penalty = tune(), mixture = tune()) %>% 
#>   set_mode("regression") %>% 
#>   set_engine("glmnet") 
#> 
#> sac_homes_workflow <- 
#>   workflow() %>% 
#>   add_recipe(sac_homes_recipe) %>% 
#>   add_model(sac_homes_spec) 
#> 
#> sac_homes_grid <- tidyr::crossing(penalty = 10^seq(-6, -1, length.out = 20), 
#>     mixture = c(0.05, 0.2, 0.4, 0.6, 0.8, 1)) 
#> 
#> sac_homes_tune <- 
#>   tune_grid(sac_homes_workflow, resamples = stop("add your rsample object"), 
#>     grid = sac_homes_grid)
```

<sup>Created on 2021-08-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

And these do run:

``` r
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
#> Warning: package 'rsample' was built under R version 4.1.1
library(modeldata)
data(ad_data)
ad_folds <- bootstraps(ad_data, times = 5)

glmnet_recipe <- 
  recipe(formula = Class ~ ., data = ad_data) %>% 
  step_novel(all_nominal_predictors()) %>% 
  step_dummy(all_nominal_predictors()) %>% 
  step_zv(all_predictors()) %>% 
  step_normalize(all_numeric_predictors()) 

glmnet_spec <- 
  logistic_reg(penalty = tune(), mixture = tune()) %>% 
  set_mode("classification") %>% 
  set_engine("glmnet") 

glmnet_workflow <- 
  workflow() %>% 
  add_recipe(glmnet_recipe) %>% 
  add_model(glmnet_spec) 

glmnet_grid <- tidyr::crossing(penalty = 10^seq(-6, -1, length.out = 20), mixture = c(0.05, 
                                                                                      0.2, 0.4, 0.6, 0.8, 1)) 

glmnet_tune <- 
  tune_grid(glmnet_workflow, resamples = ad_folds, grid = glmnet_grid) 

glmnet_tune
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 5 × 4
#>   splits            id         .metrics           .notes          
#>   <list>            <chr>      <list>             <list>          
#> 1 <split [333/120]> Bootstrap1 <tibble [240 × 6]> <tibble [0 × 1]>
#> 2 <split [333/125]> Bootstrap2 <tibble [240 × 6]> <tibble [0 × 1]>
#> 3 <split [333/127]> Bootstrap3 <tibble [240 × 6]> <tibble [0 × 1]>
#> 4 <split [333/127]> Bootstrap4 <tibble [240 × 6]> <tibble [0 × 1]>
#> 5 <split [333/123]> Bootstrap5 <tibble [240 × 6]> <tibble [0 × 1]>
```

<sup>Created on 2021-08-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

``` r
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
#> Warning: package 'rsample' was built under R version 4.1.1
data(Sacramento)
sac_folds <- vfold_cv(Sacramento, v = 5)

sac_homes_recipe <- 
  recipe(formula = price ~ ., data = Sacramento) %>% 
  step_novel(all_nominal_predictors()) %>% 
  ## This model requires the predictors to be numeric. The most common 
  ## method to convert qualitative predictors to numeric is to create 
  ## binary indicator variables (aka dummy variables) from these 
  ## predictors. 
  step_dummy(all_nominal_predictors()) %>% 
  ## Regularization methods sum up functions of the model slope 
  ## coefficients. Because of this, the predictor variables should be on 
  ## the same scale. Before centering and scaling the numeric predictors, 
  ## any predictors with a single unique value are filtered out. 
  step_zv(all_predictors()) %>% 
  step_normalize(all_numeric_predictors()) 

sac_homes_spec <- 
  linear_reg(penalty = tune(), mixture = tune()) %>% 
  set_mode("regression") %>% 
  set_engine("glmnet") 

sac_homes_workflow <- 
  workflow() %>% 
  add_recipe(sac_homes_recipe) %>% 
  add_model(sac_homes_spec) 

sac_homes_grid <- tidyr::crossing(penalty = 10^seq(-6, -1, length.out = 20), 
                                  mixture = c(0.05, 0.2, 0.4, 0.6, 0.8, 1)) 

sac_homes_tune <- 
  tune_grid(sac_homes_workflow, resamples = sac_folds, 
            grid = sac_homes_grid) 

sac_homes_tune
#> # Tuning results
#> # 5-fold cross-validation 
#> # A tibble: 5 × 4
#>   splits            id    .metrics           .notes          
#>   <list>            <chr> <list>             <list>          
#> 1 <split [745/187]> Fold1 <tibble [240 × 6]> <tibble [0 × 1]>
#> 2 <split [745/187]> Fold2 <tibble [240 × 6]> <tibble [0 × 1]>
#> 3 <split [746/186]> Fold3 <tibble [240 × 6]> <tibble [0 × 1]>
#> 4 <split [746/186]> Fold4 <tibble [240 × 6]> <tibble [0 × 1]>
#> 5 <split [746/186]> Fold5 <tibble [240 × 6]> <tibble [0 × 1]>
```

<sup>Created on 2021-08-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>