### PR TITLE
remove README.md from .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,7 +5,6 @@
 ^codecov\.yml$
 ^cran-comments\.md$
 ^README\.Rmd$
-^README\.md$
 ^\.github$
 ^_pkgdown\.yml$
 ^docs$


### PR DESCRIPTION
This PR removes `README.md` from `.Rbuildignore` making it so it will show up on CRAN and within the Package Manager UI.