### PR TITLE
updates for no-suggests checks

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -1,0 +1,59 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check-hard.yaml
+
+permissions: read-all
+
+jobs:
+  check-no-suggests:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/R/use.R
+++ b/R/use.R
@@ -29,12 +29,14 @@
 #' The syntax is opinionated and should not be considered the exact answer for
 #' every data analysis. It has reasonable defaults.
 #' @examples
-#' library(modeldata)
-#' data(ad_data)
-#' use_glmnet(Class ~ ., data = ad_data)
+#' if (rlang::is_installed("modeldata")) {
+#'   library(modeldata)
+#'   data(ad_data)
+#'   use_glmnet(Class ~ ., data = ad_data)
 #'
-#' data(Sacramento)
-#' use_glmnet(price ~ ., data = Sacramento, verbose = TRUE, prefix = "sac_homes")
+#'   data(Sacramento)
+#'   use_glmnet(price ~ ., data = Sacramento, verbose = TRUE, prefix = "sac_homes")
+#' }
 #' @export
 #' @rdname templates
 use_glmnet <- function(formula, data, prefix = "glmnet", verbose = FALSE,

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/tidymodels/usemodels/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/tidymodels/usemodels/actions/workflows/R-CMD-check.yaml)
-[![Coverage status](https://codecov.io/gh/tidymodels/usemodels/branch/main/graph/badge.svg)](https://codecov.io/github/tidymodels/usemodels?branch=main)
+[![Coverage status](https://codecov.io/gh/tidymodels/usemodels/branch/main/graph/badge.svg)](https://app.codecov.io/github/tidymodels/usemodels?branch=main)
 [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 <!-- badges: end -->
 
@@ -59,7 +59,7 @@ devtools::install_github("tidymodels/usemodels")
 
 This project is released with a [Contributor Code of Conduct](https://contributor-covenant.org/version/2/1/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.
 
-- For questions and discussions about tidymodels packages, modeling, and machine learning, please [post on RStudio Community](https://community.rstudio.com/new-topic?category_id=15&tags=tidymodels,question).
+- For questions and discussions about tidymodels packages, modeling, and machine learning, please [post on Posit Community](https://forum.posit.co/new-topic?category_id=15&tags=tidymodels,question).
 
 - If you think you have encountered a bug, please [submit an issue](https://github.com/tidymodels/usemodels/issues).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![R-CMD-check](https://github.com/tidymodels/usemodels/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/tidymodels/usemodels/actions/workflows/R-CMD-check.yaml)
 [![Coverage
-status](https://codecov.io/gh/tidymodels/usemodels/branch/main/graph/badge.svg)](https://codecov.io/github/tidymodels/usemodels?branch=main)
+status](https://codecov.io/gh/tidymodels/usemodels/branch/main/graph/badge.svg)](https://app.codecov.io/github/tidymodels/usemodels?branch=main)
 [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 <!-- badges: end -->
 
@@ -86,7 +86,7 @@ By contributing to this project, you agree to abide by its terms.
 
 - For questions and discussions about tidymodels packages, modeling, and
   machine learning, please [post on RStudio
-  Community](https://community.rstudio.com/new-topic?category_id=15&tags=tidymodels,question).
+  Community](https://forum.posit.co/new-topic?category_id=15&tags=tidymodels,question).
 
 - If you think you have encountered a bug, please [submit an
   issue](https://github.com/tidymodels/usemodels/issues).

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,4 +1,10 @@
-Lifecycle
-tidymodels
+CMD
 ORCID
+PBC
+RStudio
+Tidymodels
 funder
+lifecycle
+palmerpenguins
+reprex
+tidymodels

--- a/man/templates.Rd
+++ b/man/templates.Rd
@@ -220,10 +220,12 @@ The syntax is opinionated and should not be considered the exact answer for
 every data analysis. It has reasonable defaults.
 }
 \examples{
-library(modeldata)
-data(ad_data)
-use_glmnet(Class ~ ., data = ad_data)
+if (rlang::is_installed("modeldata")) {
+  library(modeldata)
+  data(ad_data)
+  use_glmnet(Class ~ ., data = ad_data)
 
-data(Sacramento)
-use_glmnet(price ~ ., data = Sacramento, verbose = TRUE, prefix = "sac_homes")
+  data(Sacramento)
+  use_glmnet(price ~ ., data = Sacramento, verbose = TRUE, prefix = "sac_homes")
+}
 }

--- a/tests/testthat/test-basics.R
+++ b/tests/testthat/test-basics.R
@@ -1,7 +1,10 @@
-library(modeldata)
-data("penguins")
+
 
 test_that("wrong model type", {
+  skip_if_not_installed("modeldata")
+  library(modeldata)
+  data("penguins")
+
   expect_snapshot(use_cubist(island ~ ., data = penguins), error = TRUE)
   expect_snapshot(use_C5.0(bill_depth_mm ~ ., data = penguins), error = TRUE)
 })

--- a/tests/testthat/test-clipboard.R
+++ b/tests/testthat/test-clipboard.R
@@ -1,9 +1,3 @@
-library(modeldata)
-data("penguins")
-
-penguins$island <- as.character(penguins$island)
-
-# ------------------------------------------------------------------------------
 
 # Code to loop over all tests and configurations
 
@@ -45,7 +39,13 @@ no_dummy_clip_template <- function(model, prefix, verbose, tune) {
 }
 
 verify_models <- function(model, prefix, tune, verbose) {
+  skip_if_not_installed("modeldata")
   # These are automatically skipped on CRAN
+  library(modeldata)
+  data("penguins")
+
+  penguins$island <- as.character(penguins$island)
+
   if (model != "C5.0") {
     expect_snapshot(dummy_clip_template(model, prefix, verbose, tune))
   }
@@ -56,6 +56,12 @@ verify_models <- function(model, prefix, tune, verbose) {
 
 
 test_that("all model templates with clipboard", {
+  skip_if_not_installed("modeldata")
+  library(modeldata)
+  data("penguins")
+
+  penguins$island <- as.character(penguins$island)
+
   skip_on_cran()
   skip_on_os("linux")
   skip_on_os("windows")

--- a/tests/testthat/test-templates.R
+++ b/tests/testthat/test-templates.R
@@ -1,10 +1,3 @@
-library(modeldata)
-data("penguins")
-
-penguins$island <- as.character(penguins$island)
-
-# ------------------------------------------------------------------------------
-
 # Code to loop over all tests and configurations
 
 dummy_template <- function(model, prefix, verbose, tune) {
@@ -38,6 +31,12 @@ no_dummy_template <- function(model, prefix, verbose, tune) {
 }
 
 verify_models <- function(model, prefix, tune, verbose) {
+  skip_if_not_installed("modeldata")
+  library(modeldata)
+  data("penguins")
+
+  penguins$island <- as.character(penguins$island)
+
   # These are automatically skipped on CRAN
   if (model != "C5.0") {
     expect_snapshot(dummy_template(model, prefix, verbose, tune))
@@ -49,6 +48,12 @@ verify_models <- function(model, prefix, tune, verbose) {
 
 
 test_that("all model templates", {
+  skip_if_not_installed("modeldata")
+  library(modeldata)
+  data("penguins")
+
+  penguins$island <- as.character(penguins$island)
+
   models <- c("bag_tree_rpart", "C5.0", "cubist", "dbarts", "earth", "glmnet",
               "kernlab_svm_poly", "kernlab_svm_rbf", "kknn", "mgcv", "mixOmics",
               "nnet", "ranger", "rpart", "xgboost", "xrf")


### PR DESCRIPTION
Add a GH workflow that only directly installs "hard" dependencies, i.e. Depends, Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never installed, with the exception of testthat, knitr, and rmarkdown. The cache is never used to avoid accidentally restoring a cache containing a suggested dependency.